### PR TITLE
Expect extension on _load instead of filename inference

### DIFF
--- a/snowy/io.py
+++ b/snowy/io.py
@@ -72,14 +72,14 @@ def unshape(image):
         return np.reshape(image, image.shape[:2])
     return image
 
-def _load(filename: str, linear: bool):
-    if filename.endswith('.png'):
+def _load(filename: str, extension: str, linear: bool):
+    if extension == '.png':
         img = imageio.imread(filename, 'PNG-PIL', pilmode='RGBA')
         img = np.clip(np.float64(img) / 255, 0, None)    
-    elif filename.endswith('.jpg') or filename.endswith('.jpeg'):
+    elif extension == '.jpg' or extension == '.jpeg':
         img = imageio.imread(filename)
         img = np.clip(np.float64(img) / 255, 0, None)
-    elif filename.endswith('.exr'):
+    elif extension == '.exr':
         imageio.plugins.freeimage.download()
         img = np.float64(imageio.imread(filename))
     return linearize(img) if not linear else img
@@ -93,9 +93,10 @@ def load(filename: str, linearize=True) -> np.ndarray:
     See also <a href="#reshape">reshape</a> and
     <a href="#linearize">linearize</a>  (which this calls).
     """
-    assert filename.endswith('.png') or filename.endswith('.jpeg') or \
-            filename.endswith('.jpg') or filename.endswith('.exr')
-    return reshape(np.float64(_load(filename, not linearize)))
+
+    ext = filename[filename.rfind('.'):]
+    assert ext == '.png' or ext == '.jpeg' or ext == '.jpg' or ext == '.exr'
+    return reshape(np.float64(_load(filename, ext, not linearize)))
 
 def _export(image: np.ndarray, filename: str, linear):
     image_format = None


### PR DESCRIPTION
Hey there.

I was using this to do some basic image transformation, but needed to open the image from an url instead of a file. Eventually I noticed that you're using `imageio` that does support opening from urls and that the issue was that there was no image extension in the url. 

To take advantage of that, I've changed `_load` to be less strict. Instead of checking the filename for its extension it classifies file format by accepting an extension argument.

The `load` function usage stays the same. It now extracts the extension from the filename to pass along to `_load` .

Let me know what you think.